### PR TITLE
Fixed Mail Id Typo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
         <textarea class="form-control" id="comments" name="comments" placeholder="Comment" rows="5"></textarea><br>
         <div class="row">
           <div class="col-sm-12 form-group">
-            <a href="mailto:onedevplace@email.com" target="_blank" class="btn btn-success">Send</a>
+            <a href="mailto:onedevplace@gmail.com" target="_blank" class="btn btn-success">Send</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
The contact us form was redirecting to href: "mailto: onedevplace@email.com" that is not a valid email id which I have changed to "mailto: onedevplace@gmail.com".